### PR TITLE
feat: 회원가입 페이지 수정

### DIFF
--- a/presentation/src/main/java/com/analysis/presentation/feature/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/login/LoginScreen.kt
@@ -45,10 +45,10 @@ fun LoginScreen(
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
     val emailGgzzTextFieldState = rememberSaveableGgzzTextFieldState(
-        placeholder = "이메일 입력",
+        placeholder = stringResource(R.string.login_email_placeholder),
     )
     val passwordGgzzTextFieldState = rememberSaveableGgzzTextFieldState(
-        placeholder = "비밀번호 입력",
+        placeholder = stringResource(R.string.login_password_placeholder),
     )
 
     val isFormValid = !emailGgzzTextFieldState.isError && !passwordGgzzTextFieldState.isError
@@ -88,7 +88,7 @@ fun LoginScreen(
                 Spacer(modifier = Modifier.height(50.dp))
 
                 Text(
-                    text = "로그인",
+                    text = stringResource(R.string.login_text),
                     style = GgzzTheme.typography.pretendardBold42.copy(color = Blue300),
                 )
 
@@ -128,7 +128,7 @@ fun LoginScreen(
                     ),
                 ) {
                     Text(
-                        text = "로그인",
+                        text = stringResource(R.string.login_text),
                         style = GgzzTheme.typography.pretendardSemiBold14.copy(color = White),
                     )
                 }
@@ -144,7 +144,7 @@ fun LoginScreen(
                 Spacer(modifier = Modifier.height(23.dp))
 
                 Text(
-                    text = "계정이 없으신가요?",
+                    text = stringResource(R.string.login_no_account_notice_text),
                     style = GgzzTheme.typography.pretendardBold24.copy(color = Blue300),
                 )
 
@@ -152,7 +152,7 @@ fun LoginScreen(
 
                 Text(
                     modifier = Modifier.clickable { navigateToSignUp() },
-                    text = "회원가입",
+                    text = stringResource(R.string.signup_text),
                     style = GgzzTheme.typography.pretendardMedium16,
                     textDecoration = TextDecoration.Underline,
                 )

--- a/presentation/src/main/java/com/analysis/presentation/feature/personality/component/ResultScreen.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/personality/component/ResultScreen.kt
@@ -125,7 +125,7 @@ internal fun ResultScreenContent(
 
                     Text(
                         text = stringResource(
-                            R.string.personlity_handwriting_size,
+                            R.string.personality_handwriting_size,
                             personality.traits.size.score,
                         ),
                         style = GgzzTheme.typography.pretendardSemiBold18,
@@ -153,7 +153,7 @@ internal fun ResultScreenContent(
 
                     Text(
                         text = stringResource(
-                            R.string.personlity_handwriting_pressure,
+                            R.string.personality_handwriting_pressure,
                             personality.traits.pressure.score,
                         ),
                         style = GgzzTheme.typography.pretendardSemiBold18,
@@ -181,7 +181,7 @@ internal fun ResultScreenContent(
 
                     Text(
                         text = stringResource(
-                            R.string.personlity_handwriting_inclination,
+                            R.string.personality_handwriting_inclination,
                             personality.traits.inclination.score,
                         ),
                         style = GgzzTheme.typography.pretendardSemiBold18,
@@ -209,7 +209,7 @@ internal fun ResultScreenContent(
 
                     Text(
                         text = stringResource(
-                            R.string.personlity_handwriting_shape,
+                            R.string.personality_handwriting_shape,
                             personality.traits.shape.score,
                         ),
                         style = GgzzTheme.typography.pretendardSemiBold18,

--- a/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
@@ -137,7 +137,7 @@ fun SignUpScreen(
                                 text = "* 사용 가능한 이메일입니다",
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
-                        } else {
+                        } else if(emailGgzzTextFieldState.text.isNotBlank()){
                             Text(
                                 text = "* 사용할 수 없는 이메일 입니다",
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
@@ -184,7 +184,7 @@ fun SignUpScreen(
                                 text = "* 유효한 비밀번호 입니다",
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
-                        } else {
+                        } else if(passwordGgzzTextFieldState.text.isNotBlank()){
                             Text(
                                 text = "* 비밀번호는 특수문자를 포함한 10~20자여야 합니다",
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
@@ -219,7 +219,7 @@ fun SignUpScreen(
                                 text = "* 비밀번호가 일치합니다",
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
-                        } else {
+                        } else if (passwordConfirmGgzzTextFieldState.text.isNotBlank()) {
                             Text(
                                 text = "* 비밀번호가 일치하지 않습니다",
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),

--- a/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
@@ -53,6 +53,7 @@ fun SignUpScreen(
     val emailGgzzTextFieldState = rememberSaveableGgzzTextFieldState(
         placeholder = stringResource(R.string.signup_email_placeholder),
         validate = { Patterns.EMAIL_ADDRESS.matcher(it).matches() },
+        onValueChange = {viewModel.changeEmailNotAvailable()}
     )
 
     val passwordGgzzTextFieldState = rememberSaveableGgzzTextFieldState(

--- a/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -52,17 +51,17 @@ fun SignUpScreen(
     viewModel: SignUpViewModel = hiltViewModel(),
 ) {
     val emailGgzzTextFieldState = rememberSaveableGgzzTextFieldState(
-        placeholder = "이메일 입력",
+        placeholder = stringResource(R.string.signup_email_placeholder),
         validate = { Patterns.EMAIL_ADDRESS.matcher(it).matches() },
     )
 
     val passwordGgzzTextFieldState = rememberSaveableGgzzTextFieldState(
-        placeholder = "비밀번호 입력(특수문자 포함 10~20자)",
+        placeholder = stringResource(R.string.signup_password_placeholder),
         onValueChange = { viewModel.isValidPassword(it) },
     )
 
     val passwordConfirmGgzzTextFieldState = rememberSaveableGgzzTextFieldState(
-        placeholder = "비밀번호 재입력",
+        placeholder = stringResource(R.string.signup_confirmed_password_placeholder),
         onValueChange = { viewModel.isValidConfirmedPassword(passwordGgzzTextFieldState.text, it) },
     )
 
@@ -114,7 +113,7 @@ fun SignUpScreen(
                 Spacer(modifier = Modifier.height(50.dp))
 
                 Text(
-                    text = "회원가입",
+                    text = stringResource(R.string.signup_text),
                     style = GgzzTheme.typography.pretendardBold42.copy(color = Blue300),
                 )
 
@@ -126,7 +125,7 @@ fun SignUpScreen(
                     ) {
                         Text(
                             modifier = Modifier.padding(start = 40.dp),
-                            text = "이메일",
+                            text = stringResource(R.string.signup_email_text),
                             style = GgzzTheme.typography.pretendardSemiBold16.copy(color = Blue300),
                         )
 
@@ -134,12 +133,12 @@ fun SignUpScreen(
 
                         if (isEmailAvailable) {
                             Text(
-                                text = "* 사용 가능한 이메일입니다",
+                                text = stringResource(R.string.signup_available_email_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
                         } else if(emailGgzzTextFieldState.text.isNotBlank()){
                             Text(
-                                text = "* 사용할 수 없는 이메일 입니다",
+                                text = stringResource(R.string.signup_not_available_email_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
                             )
                         }
@@ -157,7 +156,7 @@ fun SignUpScreen(
                                         .clickable(
                                             onClick = { viewModel.checkEmail(emailGgzzTextFieldState.text) },
                                         ),
-                                    text = "중복 확인",
+                                    text = stringResource(R.string.signup_check_duplication),
                                     style = GgzzTheme.typography.pretendardMedium12,
                                 )
                             }
@@ -173,7 +172,7 @@ fun SignUpScreen(
                     ) {
                         Text(
                             modifier = Modifier.padding(start = 40.dp),
-                            text = "비밀번호",
+                            text = stringResource(R.string.signup_password_text),
                             style = GgzzTheme.typography.pretendardSemiBold16.copy(color = Blue300),
                         )
 
@@ -181,12 +180,12 @@ fun SignUpScreen(
 
                         if (isPasswordAvailable) {
                             Text(
-                                text = "* 유효한 비밀번호 입니다",
+                                text = stringResource(R.string.signup_available_password_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
                         } else if(passwordGgzzTextFieldState.text.isNotBlank()){
                             Text(
-                                text = "* 비밀번호는 특수문자를 포함한 10~20자여야 합니다",
+                                text = stringResource(R.string.signup_not_available_password_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
                             )
                         }
@@ -208,7 +207,7 @@ fun SignUpScreen(
                     ) {
                         Text(
                             modifier = Modifier.padding(start = 40.dp),
-                            text = "비밀번호 확인",
+                            text = stringResource(R.string.signup_confirmed_password_text),
                             style = GgzzTheme.typography.pretendardSemiBold16.copy(color = Blue300),
                         )
 
@@ -216,12 +215,12 @@ fun SignUpScreen(
 
                         if (isConfirmedPasswordAvailable) {
                             Text(
-                                text = "* 비밀번호가 일치합니다",
+                                text = stringResource(R.string.signup_available_confirmed_password_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
                         } else if (passwordConfirmGgzzTextFieldState.text.isNotBlank()) {
                             Text(
-                                text = "* 비밀번호가 일치하지 않습니다",
+                                text = stringResource(R.string.signup_not_available_confirmed_password_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
                             )
                         }
@@ -258,7 +257,7 @@ fun SignUpScreen(
                     ),
                 ) {
                     Text(
-                        text = "회원가입",
+                        text = stringResource(R.string.signup_text),
                         style = GgzzTheme.typography.pretendardSemiBold14.copy(color = White),
                     )
                 }

--- a/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
@@ -136,12 +136,13 @@ fun SignUpScreen(
                                 text = stringResource(R.string.signup_available_email_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
-                        } else if(emailGgzzTextFieldState.text.isNotBlank()){
-                            Text(
-                                text = stringResource(R.string.signup_not_available_email_text),
-                                style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
-                            )
-                        }
+                        } else if (emailGgzzTextFieldState.text.isNotBlank())
+                            {
+                                Text(
+                                    text = stringResource(R.string.signup_not_available_email_text),
+                                    style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
+                                )
+                            }
                     }
 
                     Spacer(modifier = Modifier.height(5.dp))
@@ -183,12 +184,13 @@ fun SignUpScreen(
                                 text = stringResource(R.string.signup_available_password_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
-                        } else if(passwordGgzzTextFieldState.text.isNotBlank()){
-                            Text(
-                                text = stringResource(R.string.signup_not_available_password_text),
-                                style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
-                            )
-                        }
+                        } else if (passwordGgzzTextFieldState.text.isNotBlank())
+                            {
+                                Text(
+                                    text = stringResource(R.string.signup_not_available_password_text),
+                                    style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
+                                )
+                            }
                     }
 
                     Spacer(modifier = Modifier.height(5.dp))

--- a/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpScreen.kt
@@ -53,7 +53,7 @@ fun SignUpScreen(
     val emailGgzzTextFieldState = rememberSaveableGgzzTextFieldState(
         placeholder = stringResource(R.string.signup_email_placeholder),
         validate = { Patterns.EMAIL_ADDRESS.matcher(it).matches() },
-        onValueChange = {viewModel.changeEmailNotAvailable()}
+        onValueChange = { viewModel.changeEmailNotAvailable() },
     )
 
     val passwordGgzzTextFieldState = rememberSaveableGgzzTextFieldState(
@@ -137,13 +137,12 @@ fun SignUpScreen(
                                 text = stringResource(R.string.signup_available_email_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
-                        } else if (emailGgzzTextFieldState.text.isNotBlank())
-                            {
-                                Text(
-                                    text = stringResource(R.string.signup_not_available_email_text),
-                                    style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
-                                )
-                            }
+                        } else if (emailGgzzTextFieldState.text.isNotBlank()) {
+                            Text(
+                                text = stringResource(R.string.signup_not_available_email_text),
+                                style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
+                            )
+                        }
                     }
 
                     Spacer(modifier = Modifier.height(5.dp))
@@ -185,13 +184,12 @@ fun SignUpScreen(
                                 text = stringResource(R.string.signup_available_password_text),
                                 style = GgzzTheme.typography.pretendardRegular10.copy(color = Green400),
                             )
-                        } else if (passwordGgzzTextFieldState.text.isNotBlank())
-                            {
-                                Text(
-                                    text = stringResource(R.string.signup_not_available_password_text),
-                                    style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
-                                )
-                            }
+                        } else if (passwordGgzzTextFieldState.text.isNotBlank()) {
+                            Text(
+                                text = stringResource(R.string.signup_not_available_password_text),
+                                style = GgzzTheme.typography.pretendardRegular10.copy(color = Red600),
+                            )
+                        }
                     }
 
                     Spacer(modifier = Modifier.height(5.dp))

--- a/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpViewModel.kt
@@ -63,7 +63,7 @@ class SignUpViewModel
             }
         }
 
-        fun changeEmailNotAvailable(){
+        fun changeEmailNotAvailable() {
             _isEmailAvailable.value = false
         }
 

--- a/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/signup/SignUpViewModel.kt
@@ -63,6 +63,10 @@ class SignUpViewModel
             }
         }
 
+        fun changeEmailNotAvailable(){
+            _isEmailAvailable.value = false
+        }
+
         fun isValidPassword(password: String) {
             _isPasswordAvailable.value = PASSWORD_REGEX.matches(password)
         }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -5,6 +5,26 @@
     <string name="history_screen_title">히스토리</string>
     <string name="setting_screen_title">설정</string>
 
+    <!-- SignUp -->
+    <string name="signup_email_placeholder">이메일 입력</string>
+    <string name="signup_password_placeholder">비밀번호 입력(특수문자 포함 10~20자)</string>
+    <string name="signup_confirmed_password_placeholder">비밀번호 재입력</string>
+    <string name="signup_email_text">이메일</string>
+    <string name="signup_available_email_text">* 사용 가능한 이메일입니다</string>
+    <string name="signup_not_available_email_text">* 사용할 수 없는 이메일 입니다</string>
+    <string name="signup_check_duplication">중복 확인</string>
+    <string name="signup_password_text">비밀번호</string>
+    <string name="signup_available_password_text">* 유효한 비밀번호 입니다</string>
+    <string name="signup_not_available_password_text">* 비밀번호는 특수문자를 포함한 10~20자여야 합니다</string>
+    <string name="signup_confirmed_password_text">비밀번호 확인</string>
+    <string name="signup_available_confirmed_password_text">* 비밀번호가 일치합니다</string>
+    <string name="signup_not_available_confirmed_password_text">* 비밀번호가 일치하지 않습니다</string>
+
+    <!-- Login -->
+    <string name="login_email_placeholder">이메일 입력</string>
+    <string name="login_password_placeholder">비밀번호 입력</string>
+    <string name="login_no_account_notice_text">계정이 없으신가요?</string>
+
     <!-- Home -->
     <string name="home_top_app_bar_title">끄적</string>
     <string name="home_analysis_title">필적 감정 시작</string>
@@ -52,10 +72,10 @@
     <string name="personality_top_app_bar_title">성격 분석하기</string>
     <string name="personality_guide_title">분석할 필체 이미지 업로드</string>
     <string name="personality_guide_comment_photo_upload">당신의 성격을 알아볼 시간이에요!\n글씨가 담긴 이미지를 업로드해주세요.</string>
-    <string name="personlity_handwriting_size">글씨 크기: %s</string>
-    <string name="personlity_handwriting_pressure">필압: %s</string>
-    <string name="personlity_handwriting_inclination">기울기: %s</string>
-    <string name="personlity_handwriting_shape">자형: %s</string>
+    <string name="personality_handwriting_size">글씨 크기: %s</string>
+    <string name="personality_handwriting_pressure">필압: %s</string>
+    <string name="personality_handwriting_inclination">기울기: %s</string>
+    <string name="personality_handwriting_shape">자형: %s</string>
     <string name="personality_summary">성격 요약</string>
 
     <!-- Common -->
@@ -73,5 +93,7 @@
     <string name="percent">%d%%</string>
     <string name="personality_analyzing_ongoing_comment">필체 분석 중</string>
     <string name="personality_analyzing_guide_comment">업로드한 필체를 분석하고 있어요.\n 조금만 기다려주세요!</string>
+    <string name="login_text">로그인</string>
+    <string name="signup_text">회원가입</string>
 
 </resources>


### PR DESCRIPTION
## 🔗 관련 이슈 
close #48 

<br>

## 💡 작업 내용
- [x] 아무 텍스트도 입력하지 않았을 시 경고 문구 보이지 않도록 수정
- [x] 문자열 분리
- [x] 이메일 중복 확인 후 변경 시 유효하지 않은 이메일로 상태를 변경하도록 수정

<br>

## 📸 스크린샷 (선택)

<br>

## 👀 리뷰 참고사항 (선택)
