### PR TITLE
feat:MLKit(이미지 분석) 성능 개선

### DIFF
--- a/presentation/src/main/java/com/analysis/presentation/feature/main/MainScreen.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/main/MainScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -23,6 +24,7 @@ import com.analysis.presentation.navigation.GgzzNavController
 import com.analysis.presentation.navigation.GgzzNavHost
 import com.analysis.presentation.navigation.NavTab
 import com.analysis.presentation.theme.GgzzTheme
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @Composable
@@ -51,6 +53,10 @@ private fun MainContent(
 ) {
     val hasAccessToken by viewModel.hasAccessToken.collectAsStateWithLifecycle()
 
+    LaunchedEffect(Unit) {
+        viewModel.error.collectLatest { showErrorSnackBar(it) }
+    }
+
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
@@ -73,7 +79,10 @@ private fun MainContent(
             navController = navController,
             startDestination = navController.startDestination,
             isPreWorkEnd = hasAccessToken,
-            onStartEvent = { viewModel.getAccessTokenStatus() },
+            onStartEvent = {
+                viewModel.getAccessTokenStatus()
+                viewModel.initializeTextRecognitionModel()
+            },
             onSplashEndEvent = {
                 hasAccessToken?.let {
                     if (it) {

--- a/presentation/src/main/java/com/analysis/presentation/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/main/MainViewModel.kt
@@ -1,11 +1,16 @@
 package com.analysis.presentation.feature.main
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.analysis.domain.usecase.HasAccessTokenUseCase
+import com.analysis.presentation.util.ImageUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
@@ -16,17 +21,29 @@ class MainViewModel
     @Inject
     constructor(
         private val hasAccessTokenUseCase: HasAccessTokenUseCase,
+        private val imageUtil: ImageUtil,
     ) : ViewModel() {
+        private val _error: MutableSharedFlow<Throwable> = MutableSharedFlow()
+        val error: SharedFlow<Throwable> get() = _error.asSharedFlow()
+
         private val _hasAccessToken: MutableStateFlow<Boolean?> = MutableStateFlow(null)
         val hasAccessToken: StateFlow<Boolean?> = _hasAccessToken.asStateFlow()
 
         fun getAccessTokenStatus() {
             viewModelScope.launch {
-                hasAccessTokenUseCase().catch {
-                    // 예외 처리 필요
+                hasAccessTokenUseCase().catch { throwable ->
+                    _error.emit(throwable)
                 }.collect {
                     _hasAccessToken.emit(it)
                 }
+            }
+        }
+
+        fun initializeTextRecognitionModel(){
+            viewModelScope.launch {
+                imageUtil.analyzeImageHasTextWithKorean(Uri.EMPTY, isInitializeModelWork = true).catch { throwable ->
+                    _error.emit(throwable)
+                }.collect{}
             }
         }
     }

--- a/presentation/src/main/java/com/analysis/presentation/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/main/MainViewModel.kt
@@ -39,11 +39,11 @@ class MainViewModel
             }
         }
 
-        fun initializeTextRecognitionModel(){
+        fun initializeTextRecognitionModel() {
             viewModelScope.launch {
                 imageUtil.analyzeImageHasTextWithKorean(Uri.EMPTY, isInitializeModelWork = true).catch { throwable ->
                     _error.emit(throwable)
-                }.collect{}
+                }.collect {}
             }
         }
     }

--- a/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
@@ -1,8 +1,6 @@
 package com.analysis.presentation.feature.verify
 
 import android.net.Uri
-import android.os.Debug
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.analysis.domain.usecase.AnalysisUseCase
@@ -64,7 +62,7 @@ internal class VerifyViewModel
                 }
 
                 var isErrorEmitted = false
-                val results = validUris.map {uri->
+                val results = validUris.map { uri ->
                     async {
                         val hasText = imageUtil.analyzeImageHasTextWithKorean(uri)
                             .catch {
@@ -79,7 +77,7 @@ internal class VerifyViewModel
 
                 val finalResults = results.awaitAll()
                 val finalUris = finalResults.filter { it.second }.map { it.first }
-                if (uris.size!=finalUris.size) _errorMsgResId.emit(R.string.invalid_photo_no_text_or_no_korean)
+                if (uris.size != finalUris.size) _errorMsgResId.emit(R.string.invalid_photo_no_text_or_no_korean)
                 _selectedComparisonUris.emit(finalUris)
             }
         }

--- a/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
@@ -71,14 +71,13 @@ internal class VerifyViewModel
                                     isErrorEmitted = true
                                 }
                             }.first()
-                        Pair(uri, hasText)
+                        if(hasText) uri else null
                     }
                 }
 
-                val finalResults = results.awaitAll()
-                val finalUris = finalResults.filter { it.second }.map { it.first }
-                if (uris.size != finalUris.size) _errorMsgResId.emit(R.string.invalid_photo_no_text_or_no_korean)
-                _selectedComparisonUris.emit(finalUris)
+                val finalResults = results.awaitAll().filterNotNull()
+                if (uris.size != finalResults.size) _errorMsgResId.emit(R.string.invalid_photo_no_text_or_no_korean)
+                _selectedComparisonUris.emit(finalResults)
             }
         }
 

--- a/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
@@ -71,7 +71,7 @@ internal class VerifyViewModel
                                     isErrorEmitted = true
                                 }
                             }.first()
-                        if(hasText) uri else null
+                        if (hasText) uri else null
                     }
                 }
 

--- a/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
@@ -1,6 +1,7 @@
 package com.analysis.presentation.feature.verify
 
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.analysis.domain.usecase.AnalysisUseCase
@@ -9,6 +10,8 @@ import com.analysis.presentation.feature.verify.model.VerificationUiState
 import com.analysis.presentation.feature.verify.model.toVerificationResultUiState
 import com.analysis.presentation.util.ImageUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -16,6 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -58,24 +62,26 @@ internal class VerifyViewModel
                     _errorMsgResId.emit(R.string.invalid_photo_format)
                 }
 
-                val finalUris = mutableListOf<Uri>()
                 var isErrorEmitted = false
-                var sawTextError = false
-                validUris.forEach { uri ->
-                    imageUtil.analyzeImageHasTextWithKorean(uri).catch {
-                        if (!isErrorEmitted) {
-                            _error.emit(it)
-                            isErrorEmitted = true
-                        }
-                    }.collect { hasTextWithKorean ->
-                        if (hasTextWithKorean) {
-                            finalUris.add(uri)
-                            return@collect
-                        }
-                        sawTextError = true
+                val startTime = System.currentTimeMillis()
+                val results = validUris.map {uri->
+                    async {
+                        val hasText = imageUtil.analyzeImageHasTextWithKorean(uri)
+                            .catch {
+                                if (!isErrorEmitted) {
+                                    _error.emit(it)
+                                    isErrorEmitted = true
+                                }
+                            }.first()
+                        Pair(uri, hasText)
                     }
                 }
-                if (sawTextError) _errorMsgResId.emit(R.string.invalid_photo_no_text_or_no_korean)
+
+                val finalResults = results.awaitAll()
+                val finalUris = finalResults.filter { it.second }.map { it.first }
+                val endTime = System.currentTimeMillis()
+                Log.d("MLKitPerformance", "elapsed=${endTime - startTime}ms")
+                if (uris.size!=finalUris.size) _errorMsgResId.emit(R.string.invalid_photo_no_text_or_no_korean)
                 _selectedComparisonUris.emit(finalUris)
             }
         }

--- a/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
+++ b/presentation/src/main/java/com/analysis/presentation/feature/verify/VerifyViewModel.kt
@@ -1,6 +1,7 @@
 package com.analysis.presentation.feature.verify
 
 import android.net.Uri
+import android.os.Debug
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -63,7 +64,6 @@ internal class VerifyViewModel
                 }
 
                 var isErrorEmitted = false
-                val startTime = System.currentTimeMillis()
                 val results = validUris.map {uri->
                     async {
                         val hasText = imageUtil.analyzeImageHasTextWithKorean(uri)
@@ -79,8 +79,6 @@ internal class VerifyViewModel
 
                 val finalResults = results.awaitAll()
                 val finalUris = finalResults.filter { it.second }.map { it.first }
-                val endTime = System.currentTimeMillis()
-                Log.d("MLKitPerformance", "elapsed=${endTime - startTime}ms")
                 if (uris.size!=finalUris.size) _errorMsgResId.emit(R.string.invalid_photo_no_text_or_no_korean)
                 _selectedComparisonUris.emit(finalUris)
             }

--- a/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
+++ b/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
@@ -89,9 +89,9 @@ class ImageUtil
             uri: Uri,
             maxRetries: Int = 5,
             delayMs: Long = 1000L,
-            isInitializeModelWork:Boolean = false,
+            isInitializeModelWork: Boolean = false,
         ): Flow<Boolean> {
-            val image = if(isInitializeModelWork) DUMMY_IMAGE else InputImage.fromFilePath(appContext, uri)
+            val image = if (isInitializeModelWork) DUMMY_IMAGE else InputImage.fromFilePath(appContext, uri)
 
             repeat(maxRetries) { attempt ->
                 try {
@@ -124,6 +124,8 @@ class ImageUtil
             private val ALLOWED_MIME_TYPES = listOf("image/png", "image/jpeg", "image/jpg")
             private const val CHECK_KOREAN_REGEX = ".*[\\uAC00-\\uD7AF].*"
             private val DUMMY_IMAGE = InputImage.fromBitmap(
-                Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888), 0)
+                Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888),
+                0,
+            )
         }
     }

--- a/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
+++ b/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
@@ -8,6 +8,7 @@ import com.analysis.presentation.R
 import com.google.mlkit.common.MlKitException
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.TextRecognizer
 import com.google.mlkit.vision.text.korean.KoreanTextRecognizerOptions
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.delay
@@ -28,6 +29,10 @@ class ImageUtil
     ) {
         private val resolver: ContentResolver
             get() = appContext.contentResolver
+
+        private val recognizer: TextRecognizer by lazy {
+            TextRecognition.getClient(KoreanTextRecognizerOptions.Builder().build())
+        }
 
         fun isValidFormat(uri: Uri): Boolean {
             val size = resolver.openAssetFileDescriptor(uri, "r")?.use { it.length }
@@ -84,7 +89,6 @@ class ImageUtil
             maxRetries: Int = 5,
             delayMs: Long = 1000L,
         ): Flow<Boolean> {
-            val recognizer = TextRecognition.getClient(KoreanTextRecognizerOptions.Builder().build())
             val image = InputImage.fromFilePath(appContext, uri)
 
             repeat(maxRetries) { attempt ->

--- a/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
+++ b/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
@@ -2,6 +2,7 @@ package com.analysis.presentation.util
 
 import android.content.ContentResolver
 import android.content.Context
+import android.graphics.Bitmap
 import android.net.Uri
 import android.provider.OpenableColumns
 import com.analysis.presentation.R
@@ -88,8 +89,9 @@ class ImageUtil
             uri: Uri,
             maxRetries: Int = 5,
             delayMs: Long = 1000L,
+            isInitializeModelWork:Boolean = false,
         ): Flow<Boolean> {
-            val image = InputImage.fromFilePath(appContext, uri)
+            val image = if(isInitializeModelWork) DUMMY_IMAGE else InputImage.fromFilePath(appContext, uri)
 
             repeat(maxRetries) { attempt ->
                 try {
@@ -103,7 +105,7 @@ class ImageUtil
                     return flow { emit(hasAnyKorean) }
                 } catch (e: MlKitException) {
                     if (e.errorCode == MlKitException.UNAVAILABLE) {
-                        if (attempt + 1 == maxRetries) {
+                        if (attempt + 1 == maxRetries && !isInitializeModelWork) {
                             throw IllegalArgumentException(appContext.getString(R.string.error_try_later))
                         }
                         delay(delayMs)
@@ -121,5 +123,7 @@ class ImageUtil
             private const val MAX_SIZE_BYTES = 10L * 1024 * 1024
             private val ALLOWED_MIME_TYPES = listOf("image/png", "image/jpeg", "image/jpg")
             private const val CHECK_KOREAN_REGEX = ".*[\\uAC00-\\uD7AF].*"
+            private val DUMMY_IMAGE = InputImage.fromBitmap(
+                Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888), 0)
         }
     }

--- a/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
+++ b/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
@@ -91,7 +91,7 @@ class ImageUtil
             delayMs: Long = 1000L,
             isInitializeModelWork: Boolean = false,
         ): Flow<Boolean> {
-            val image = if (isInitializeModelWork) DUMMY_IMAGE else InputImage.fromFilePath(appContext, uri)
+            val image = if (isInitializeModelWork) createDummyImage() else InputImage.fromFilePath(appContext, uri)
 
             repeat(maxRetries) { attempt ->
                 try {
@@ -119,13 +119,14 @@ class ImageUtil
             throw IllegalArgumentException(appContext.getString(R.string.unknown_error_snackbar))
         }
 
+        private fun createDummyImage() = InputImage.fromBitmap(
+            Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888),
+            0,
+        )
+
         companion object {
             private const val MAX_SIZE_BYTES = 10L * 1024 * 1024
             private val ALLOWED_MIME_TYPES = listOf("image/png", "image/jpeg", "image/jpg")
             private const val CHECK_KOREAN_REGEX = ".*[\\uAC00-\\uD7AF].*"
-            private val DUMMY_IMAGE = InputImage.fromBitmap(
-                Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888),
-                0,
-            )
         }
     }

--- a/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
+++ b/presentation/src/main/java/com/analysis/presentation/util/ImageUtil.kt
@@ -120,7 +120,7 @@ class ImageUtil
         }
 
         private fun createDummyImage() = InputImage.fromBitmap(
-            Bitmap.createBitmap(32, 32, Bitmap.Config.ARGB_8888),
+            Bitmap.createBitmap(MIN_INPUT_IMAGE_SIZE, MIN_INPUT_IMAGE_SIZE, Bitmap.Config.ARGB_8888),
             0,
         )
 
@@ -128,5 +128,6 @@ class ImageUtil
             private const val MAX_SIZE_BYTES = 10L * 1024 * 1024
             private val ALLOWED_MIME_TYPES = listOf("image/png", "image/jpeg", "image/jpg")
             private const val CHECK_KOREAN_REGEX = ".*[\\uAC00-\\uD7AF].*"
+            private const val MIN_INPUT_IMAGE_SIZE = 32
         }
     }

--- a/presentation/src/test/java/com/analysis/presentation/feature/main/MainViewModelTest.kt
+++ b/presentation/src/test/java/com/analysis/presentation/feature/main/MainViewModelTest.kt
@@ -2,6 +2,7 @@ package com.analysis.presentation.feature.main
 
 import com.analysis.domain.usecase.HasAccessTokenUseCase
 import com.analysis.presentation.rule.MainDispatcherRule
+import com.analysis.presentation.util.ImageUtil
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.flow.first
@@ -17,7 +18,8 @@ class MainViewModelTest {
     val dispatcherRule = MainDispatcherRule()
 
     private val hasAccessTokenUseCase: HasAccessTokenUseCase = mockk()
-    private val viewModel = MainViewModel(hasAccessTokenUseCase)
+    private val imageUtil: ImageUtil = mockk()
+    private val viewModel = MainViewModel(hasAccessTokenUseCase, imageUtil)
 
     @Test
     @DisplayName("AccessToken 여부를 확인한다")


### PR DESCRIPTION
## 🔗 관련 이슈 
close #59 

<br>

## 💡 작업 내용
- [x] MLKit(이미지 분석) 성능 개선

<br>

## 📸 스크린샷 (선택)

<br>

## 👀 리뷰 참고사항 (선택)
### 1. 스플래시 화면에서 모델 메모리에 로드
ML Kit에서는 모델만 따로 메모리에 올리는 API는 제공하지 않는다.
그래서 선택한 방법은, 앱 진입 시 스플래시 화면에서 더미 이미지를 활용한 워밍업 분석을 수행하는 방식

`isInitializeModelWork`가 `true`일 경우, 실제 이미지 대신 더미 이미지를 활용해 워밍업 분석을 진행하도록 구현

### 2. 여러 장 이미지 분석 병렬 처리
기존에는 사용자가 선택한 이미지들을 다음과 같이 forEach를 이용해 순차적으로 처리
-> 코루틴의 async를 활용해 동시에 분석 요청을 보내도록 변경

### 3. Recognizer 인스턴스 재사용
함수가 호출될 때마다 TextRecognizer 인스턴스를 매번 새로 생성하고 있다.

이는 불필요한 객체 생성 오버헤드를 발생시킬 수 있고, 내부적으로도 리소스를 더 사용할 수 있는 여지가 있다.

이러한 오버헤드를 줄이기 위해, TextRecognizer를 지연 초기화된 싱글 인스턴스로 관리하도록 리팩토링

### 성능 개선 결과

<img width="529" height="158" alt="스크린샷 2025-07-16 오후 3 50 07" src="https://github.com/user-attachments/assets/f5dfb965-0eeb-4e59-81e4-bb130172680a" />
